### PR TITLE
Implemented -c, --config flag and fixed CLI arg reader

### DIFF
--- a/Learn2Blog.csproj
+++ b/Learn2Blog.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.4" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Tommy" Version="3.1.2" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To build and run this C# console application, follow these steps:
 
 Before you begin, make sure you have the following prerequisites installed on your system:
 
--   [.NET SDK](https://dotnet.microsoft.com/en-us/download) - Ensure you have the .NET SDK installed to build and run C# applications.
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download) - Ensure you have the .NET SDK installed to build and run C# applications.
 
 ### 1. Clone the Repository
 
@@ -64,7 +64,7 @@ Run the app by using one of the options or provide an input argument:
 ```bash
 # converts the input.txt file into html and outputs in the specified output directory
 # can also be used with a directory as the input
-./Learn2Blog.exe -o inputSample.txt outputDirectory
+./Learn2Blog.exe -o outputDirectory inputSample.txt
 ```
 
 ```bash
@@ -83,24 +83,30 @@ Run the app by using one of the options or provide an input argument:
 ./Learn2Blog.exe inputSample.md
 ```
 
+```bash
+# uses the specified config file to convert the input.txt file into html and outputs in the default directory
+# the -o option from CLI will be ignored if specified in the config file
+./Learn2Blog.exe -c config.toml -o outputDirectory inputSample.txt
+```
 
 ### Notes on Usage:
 
--   The app will place the output in a directory called `til` by default.
--   If the output directory is specified with the `-o` flag, this directory will be used instead.
--   If the output directory already exists, the app will overwrite the files in it.
--   The name of the output file is the same name as the input file.
--   The title of the html file is the same as the input file name by default, unless a title is specified in the input file.
--   A title in the input file is the first line of the file followed by 2 empty lines:
+- The app will place the output in a directory called `til` by default.
+- If the output directory is specified with the `-o` flag, this directory will be used instead.
+- If the output directory already exists, the app will overwrite the files in it.
+- The name of the output file is the same name as the input file.
+- The title of the html file is the same as the input file name by default, unless a title is specified in the input file.
+- A title in the input file is the first line of the file followed by 2 empty lines:
 
-    ```txt
-    This is the title
-    <empty line>
-    <empty line>
-    This is the content of the file
-    ```
+  ```txt
+  This is the title
+  <empty line>
+  <empty line>
+  This is the content of the file
+  ```
 
--   The app will convert the bold markdown syntax into the `<strong>` html tag
+- The app will convert the bold markdown syntax into the `<strong>` html tag
+- If the `-c` flag is used, the app will use the specified config file to convert the input file.
 
 ## Bug Report
 
@@ -111,4 +117,4 @@ To report a bug simply create a new `issue` on the repository with the following
 - Steps to reproduce the bug (what were you doing when encountered the bug)
 - The expected result of your action versus the produced result
 
-Including as much detail will help me easily replicate the bug and investigate the cause and a solution. 
+Including as much detail will help me easily replicate the bug and investigate the cause and a solution.

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+output = "test"
+stylesheet = "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+title = "TILvert Blogs"
+lang = "en-CA"

--- a/src/CommandLineParser.cs
+++ b/src/CommandLineParser.cs
@@ -46,19 +46,8 @@ namespace Learn2Blog
                     case "--config":
                         if (i + 1 < args.Length)
                         {
-                            options.ConfigPath = args[i + 1];
-                            i++; // Skip the next argument as it is the config file path
-
-                            CommandLineOptions? config = ParseConfigFile(options.ConfigPath ?? "");
-
-                            if (config != null)
-                            {
-                                options.OutputPath = config.OutputPath;
-                            }
-                            else
-                            {
-                                return null;
-                            }
+                            // If -c flag is present, parse the config file and ignore all other flags
+                            return ParseConfigFile(args[i + 1]);
                         }
                         else
                         {
@@ -66,7 +55,6 @@ namespace Learn2Blog
                             CommandLineUtils.ShowHelp();
                             return null;
                         }
-                        break;
                     default:
                         // The last argument without a flag is treated as the input file
                         options.InputPath = args[i];

--- a/src/CommandLineParser.cs
+++ b/src/CommandLineParser.cs
@@ -47,7 +47,10 @@ namespace Learn2Blog
                         if (i + 1 < args.Length)
                         {
                             // If -c flag is present, parse the config file and ignore all other flags
-                            return ParseConfigFile(args[i + 1]);
+                            var config = ParseConfigFile(args[i + 1]);
+                            if (config != null)
+                                config.InputPath = args[^1];
+                            return config;
                         }
                         else
                         {

--- a/src/CommandLineUtils.cs
+++ b/src/CommandLineUtils.cs
@@ -23,9 +23,10 @@ namespace Learn2Blog
             Console.WriteLine("NOTE:<input> can be a file or a directory");
             Console.WriteLine("------------------------------------------------------------");
             Console.WriteLine("Options:");
-            Console.WriteLine("  -h, --ShowHelp     Show the help menu");
+            Console.WriteLine("  -h, --help         Show the help menu");
             Console.WriteLine("  -v, --version      Show version information");
             Console.WriteLine("  -o, --output       Specify output directory");
+            Console.WriteLine("  -c, --config       Specify config file");
             Console.WriteLine("------------------------------------------------------------");
         }
 


### PR DESCRIPTION
## What has been done

Added feature to read TOML config files into the program.
Changed the `ParseCommandLineArgs` function to loop through the arguments and assign them accordingly. The input path will always come last in this case.

## What has been changed 

- Added the `Tommy` TOML parsing library
- Added function to read and process the TOML file in the `CommandLineParser` class
- Modified `ParseCommandLineArgs` function to read arguments in a standard way

## Notes

I implemented the basics of the CLI reading and would like to leave it up to you how you would like to handle errors more gracefully currently the code will attempt to read the config file, and exit the program if it fails to do so.
A more graceful exit strategy would be to maybe allow the config file to be ignored if it fails to read it and continue on with the CLI args.
There are also possibilities of the config file having TOML syntax errors which could crash the app, the `Tommy` library provides a graceful method that attempts to parse the table as best it can before exiting, this table can also be used to run the program regardless of the error, and simply show a warning of the syntax error.